### PR TITLE
Update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,8 @@
       "3.16",
       "3.18",
       "3.20",
-      "3.22"
+      "3.22",
+      "40.0"
    ],
    "uuid": "uptime-indicator@gniourfgniourf.gmail.com",
    "name": "Uptime Indicator",


### PR DESCRIPTION
As reported by users on the [Gnome Extensions page](https://extensions.gnome.org/extension/508/uptime-indicator/),
apparently the extension still works on Gnome 40.0.
I installed it as suggested in the comment section and indeed it works perfectly.

Adding the shell version in the metadata file should suffice until a bug is reported.