### PR TITLE
Version should not have minor version number

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
       "3.18",
       "3.20",
       "3.22",
-      "40.0"
+      "40"
    ],
    "uuid": "uptime-indicator@gniourfgniourf.gmail.com",
    "name": "Uptime Indicator",


### PR DESCRIPTION
Apparently I made a mistake there.
When updating minor version of Gnome, it isn't  "40.0" anymore and so the extension is believed incompatible by Gnome Extensions system.

I confirmed it works again when removing the `.0` part.