### PR TITLE
Fix deprecation warnings

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -46,7 +46,7 @@ const UptimeIndicator = GObject.registerClass(
                 name: "uptime-indicator-buttonText",
                 y_align: Clutter.ActorAlign.CENTER
             });
-            this.actor.add_actor(this.buttonText);
+            this.add_actor(this.buttonText);
 
             /* Find starting date and */
             let timestamp = this._get_timestamps()[0];
@@ -57,8 +57,8 @@ const UptimeIndicator = GObject.registerClass(
             this._mymenutitle = new PopupMenu.PopupMenuItem(this._started, { reactive: false });
             this.menu.addMenuItem(this._mymenutitle);
 
-            this.actor.connect('button-press-event', this._refresh.bind(this));
-            this.actor.connect('key-press-event', this._refresh.bind(this));
+            this.connect('button-press-event', this._refresh.bind(this));
+            this.connect('key-press-event', this._refresh.bind(this));
 
             this._set_refresh_rate(1)
             this._change_timeoutloop = true;


### PR DESCRIPTION
Enabling the extension would raise deprecation warnings inside the systemd journal:

```
Mär 17 14:48:34 localhost gnome-shell[7701]: Usage of object.actor is deprecated for UptimeIndicator
                                               get@resource:///org/gnome/shell/ui/environment.js:388:29
                                               _init@/home/stefan/.local/share/gnome-shell/extensions/uptime-indicator@gniourfgniourf.gmail.com/extension.js:49:13
                                               enable@/home/stefan/.local/share/gnome-shell/extensions/uptime-indicator@gniourfgniourf.gmail.com/extension.js:156:32
                                               _callExtensionEnable@resource:///org/gnome/shell/ui/extensionSystem.js:168:32
                                               loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:367:26
                                               _loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:613:18
                                               collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:27:28
                                               _loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:592:19
                                               _enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:622:18
                                               _sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:653:18
                                               init@resource:///org/gnome/shell/ui/extensionSystem.js:56:14
                                               _initializeUI@resource:///org/gnome/shell/ui/main.js:265:22
                                               start@resource:///org/gnome/shell/ui/main.js:162:5
                                               @resource:///org/gnome/shell/ui/init.js:6:17
Mär 17 14:48:34 localhost gnome-shell[7701]: Usage of object.actor is deprecated for UptimeIndicator
                                               get@resource:///org/gnome/shell/ui/environment.js:388:29
                                               _init@/home/stefan/.local/share/gnome-shell/extensions/uptime-indicator@gniourfgniourf.gmail.com/extension.js:60:13
                                               enable@/home/stefan/.local/share/gnome-shell/extensions/uptime-indicator@gniourfgniourf.gmail.com/extension.js:156:32
                                               _callExtensionEnable@resource:///org/gnome/shell/ui/extensionSystem.js:168:32
                                               loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:367:26
                                               _loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:613:18
                                               collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:27:28
                                               _loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:592:19
                                               _enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:622:18
                                               _sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:653:18
                                               init@resource:///org/gnome/shell/ui/extensionSystem.js:56:14
                                               _initializeUI@resource:///org/gnome/shell/ui/main.js:265:22
                                               start@resource:///org/gnome/shell/ui/main.js:162:5
                                               @resource:///org/gnome/shell/ui/init.js:6:17
Mär 17 14:48:34 localhost gnome-shell[7701]: Usage of object.actor is deprecated for UptimeIndicator
                                               get@resource:///org/gnome/shell/ui/environment.js:388:29
                                               _init@/home/stefan/.local/share/gnome-shell/extensions/uptime-indicator@gniourfgniourf.gmail.com/extension.js:61:13
                                               enable@/home/stefan/.local/share/gnome-shell/extensions/uptime-indicator@gniourfgniourf.gmail.com/extension.js:156:32
                                               _callExtensionEnable@resource:///org/gnome/shell/ui/extensionSystem.js:168:32
                                               loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:367:26
                                               _loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:613:18
                                               collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:27:28
                                               _loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:592:19
                                               _enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:622:18
                                               _sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:653:18
                                               init@resource:///org/gnome/shell/ui/extensionSystem.js:56:14
                                               _initializeUI@resource:///org/gnome/shell/ui/main.js:265:22
                                               start@resource:///org/gnome/shell/ui/main.js:162:5
                                               @resource:///org/gnome/shell/ui/init.js:6:17
```

This PR fixes these warnings and does not seem to have side effects (as least on my setup).

Upstream PR: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/487