### PR TITLE
Some adjustments to the CSS code to allow the extension to regulate the font style as the default to display along with others in the top bar.

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,5 +1,11 @@
 #uptime-indicator-buttonText {
-   text-align: center;
-   font-style: italic;
+  text-align: center;
 }
 
+#uptime-indicator-buttonText .normal {
+  font-style: normal;
+}
+
+#uptime-indicator-buttonText .italic {
+  font-style: italic;
+}


### PR DESCRIPTION
Hello there. I made a few changes to the CSS file as seeing the font is only available in italic style, which wasn't an option for me as a user. After a bit of work, I tested it within GNOME Builder by downloading the edited code, and I think it now works pretty well as it displays the font the same as the other extensions (since I use the regular font style). But now you'll need to change systematic font in order to access the italic font as you wish. Hate to say it, but that's what it is.

I believe it is more plausible to look at style efficiency, which makes it appear more eye-catching and not discouraged by design inaccuracy. So, I'm hoping that you'll approve this pull request, and please let me know if everything seems good. Thank you.